### PR TITLE
added wrappers for mpi_send and mpi_recv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
       os: windows
       before_install:
         - choco install python --version 3.8.2
-      env: PATH=/c/Python38:/c/Python38/Scripts:/c/"Microsoft MPI"/Bin:/c/"Program Files"/"Microsoft MPI"/Bin:$PATH
+      env: PATH=/c/Python38:/c/Python38/Scripts:/c/Microsoft MPI/Bin:/c/Program Files/Microsoft MPI/Bin:$PATH
 
 install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,9 +78,18 @@ script:
       done;
     else
       if [[ $CODECOV == 'TRUE' ]]; then
-        python$PY_SFX -m pytest --cov-report term --cov=MPyDATA MPyDATA_tests;
+        python$PY_SFX -m pytest -k "not test_mpi" --cov-report term --cov=MPyDATA MPyDATA_tests;
       else
-        mpirun -n 2 python$PY_SFX -m pytest MPyDATA_tests;
+        python$PY_SFX -m pytest MPyDATA_tests -k "not test_mpi";
+      fi;
+      if [[ $TRAVIS_OS_NAME == 'windows' ]]; then
+        mpiexec /np 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;
+      else
+        if [[ $MPI == 'mpich' ]]; then
+          mpiexec -n 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;
+        else
+          mpirun -n 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;
+        fi;
       fi;
     fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
       os: windows
       before_install:
         - choco install python --version 3.8.2
-      env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
+      env: PATH=/c/Python38:/c/Python38/Scripts:/c/"Microsoft MPI"/Bin:/c/"Program Files"/"Microsoft MPI"/Bin:$PATH
 
 install:
   - |
@@ -83,7 +83,7 @@ script:
         python$PY_SFX -m pytest MPyDATA_tests -k "not test_mpi";
       fi;
       if [[ $TRAVIS_OS_NAME == 'windows' ]]; then
-        mpiexec.exe /np 2 python$PY_SFX.exe -m pytest -k "test_mpi" MPyDATA_tests;
+        mpiexec /np 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;
       else
         if [[ $MPI == 'mpich' ]]; then
           mpiexec -n 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ install:
       curl -L $WEB_ADDRESS/msmpisdk.msi -o msmpisdk.msi
       ./msmpisetup.exe
       msiexec //i msmpisdk.msi
+      export PATH=/c/Program\ Files/Microsoft\ MPI/bin:$PATH
     fi;
   - pip$PY_SFX install -U -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ script:
         python$PY_SFX -m pytest MPyDATA_tests -k "not test_mpi";
       fi;
       if [[ $TRAVIS_OS_NAME == 'windows' ]]; then
-        echo "mpiexec /np 2 python$PY_SFX -m pytest -k test_mpi MPyDATA_tests";
+        mpiexec /np 2 python$PY_SFX -m pytest -k test_mpi MPyDATA_tests;
       else
         if [[ $MPI == 'mpich' ]]; then
           mpiexec -n 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
       os: windows
       before_install:
         - choco install python --version 3.8.2
-      env: PATH=/c/Python38:/c/Python38/Scripts:/c/Microsoft MPI/Bin:/c/Program Files/Microsoft MPI/Bin:$PATH
+      env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
 
 install:
   - |
@@ -83,7 +83,7 @@ script:
         python$PY_SFX -m pytest MPyDATA_tests -k "not test_mpi";
       fi;
       if [[ $TRAVIS_OS_NAME == 'windows' ]]; then
-        mpiexec /np 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;
+        echo "mpiexec /np 2 python$PY_SFX -m pytest -k test_mpi MPyDATA_tests";
       else
         if [[ $MPI == 'mpich' ]]; then
           mpiexec -n 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ script:
         python$PY_SFX -m pytest MPyDATA_tests -k "not test_mpi";
       fi;
       if [[ $TRAVIS_OS_NAME == 'windows' ]]; then
-        mpiexec /np 2 python$PY_SFX -m pytest -k test_mpi MPyDATA_tests;
+        mpiexec -n 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;
       else
         if [[ $MPI == 'mpich' ]]; then
           mpiexec -n 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,23 +79,15 @@ script:
       done;
     else
       if [[ $CODECOV == 'TRUE' ]]; then
-        python$PY_SFX -m pytest -k "not test_mpi" --cov-report term --cov=MPyDATA MPyDATA_tests;
+        python$PY_SFX -m pytest -k "not test_mpi" --cov-report term --cov=MPyDATA MPyDATA_tests || exit 1;
       else
-        python$PY_SFX -m pytest MPyDATA_tests -k "not test_mpi";
+        python$PY_SFX -m pytest MPyDATA_tests -k "not test_mpi" || exit 1;
       fi;
-      if [[ $TRAVIS_OS_NAME == 'windows' ]]; then
-        mpiexec -n 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;
-      else
-        if [[ $MPI == 'mpich' ]]; then
-          mpiexec -n 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;
-        else
-          mpirun -n 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;
-        fi;
-      fi;
+      mpiexec -n 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests || exit 1;
     fi;
 
 after_success:
   - |
     if [[ $CODECOV == 'TRUE' ]]; then
-      codecov;
+      codecov || exit 1;
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
         python$PY_SFX -m pytest MPyDATA_tests -k "not test_mpi";
       fi;
       if [[ $TRAVIS_OS_NAME == 'windows' ]]; then
-        mpiexec /np 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;
+        mpiexec.exe /np 2 python$PY_SFX.exe -m pytest -k "test_mpi" MPyDATA_tests;
       else
         if [[ $MPI == 'mpich' ]]; then
           mpiexec -n 2 python$PY_SFX -m pytest -k "test_mpi" MPyDATA_tests;

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ script:
       if [[ $CODECOV == 'TRUE' ]]; then
         python$PY_SFX -m pytest --cov-report term --cov=MPyDATA MPyDATA_tests;
       else
-        python$PY_SFX -m pytest MPyDATA_tests;
+        mpirun -n 2 python$PY_SFX -m pytest MPyDATA_tests;
       fi;
     fi;
 

--- a/MPyDATA/mpi.py
+++ b/MPyDATA/mpi.py
@@ -9,7 +9,7 @@ if MPI._sizeof(MPI.Comm) == ctypes.sizeof(ctypes.c_int):
     _MPI_Comm_t = ctypes.c_int
 else:
     _MPI_Comm_t = ctypes.c_void_p
-_MPI_Datatype_t = ctypes.c_int
+_MPI_Datatype_t = ctypes.c_void_p
 _MPI_Status_ptr_t = ctypes.c_void_p
 
 if platform.system() == 'Linux':
@@ -36,6 +36,8 @@ _MPI_Comm_rank.argtypes = [_MPI_Comm_t, ctypes.c_void_p]
 
 _MPI_Comm_World_ptr = MPI._addressof(MPI.COMM_WORLD)
 
+_MPI_Double_ptr = MPI._addressof(MPI.DOUBLE)
+
 # int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,  MPI_Comm comm)
 _MPI_Send = libmpi.MPI_Send
 _MPI_Send.restype = ctypes.c_int
@@ -49,12 +51,27 @@ _MPI_Recv.argtypes = [ctypes.c_void_p, ctypes.c_int, _MPI_Datatype_t, ctypes.c_i
 def _MPI_Comm_world():
     return _MPI_Comm_t.from_address(_MPI_Comm_World_ptr)
 
-
 @numba.extending.overload(_MPI_Comm_world)
 def _MPI_Comm_world_njit():
     def impl():
         return numba.carray(
             address_as_void_pointer(_MPI_Comm_World_ptr),
+            shape=(1,),
+            dtype=np.intp
+        )[0]
+    return impl
+
+
+def _MPI_Double():
+    return _MPI_Datatype_t.from_address(_MPI_Double_ptr)
+
+# WIN DOUBLE - 0x4c00080b
+
+@numba.extending.overload(_MPI_Double)
+def _MPI_Double_njit():
+    def impl():
+        return numba.carray(
+            address_as_void_pointer(_MPI_Double_ptr),
             shape=(1,),
             dtype=np.intp
         )[0]
@@ -96,130 +113,14 @@ def rank():
     assert status == 0
     return value[0]
 
-# TEMP: from WIN MSDN (https://docs.microsoft.com/en-us/message-passing-interface/mpi-datatype-enumeration)
-MPI_DATATYPE_NULL          = 0x0c000000
-MPI_CHAR                   = 0x4c000101
-MPI_UNSIGNED_CHAR          = 0x4c000102
-MPI_SHORT                  = 0x4c000203
-MPI_UNSIGNED_SHORT         = 0x4c000204
-MPI_INT                    = 0x4c000405
-MPI_UNSIGNED               = 0x4c000406
-MPI_LONG                   = 0x4c000407
-MPI_UNSIGNED_LONG          = 0x4c000408
-MPI_LONG_LONG_INT          = 0x4c000809
-MPI_LONG_LONG              = MPI_LONG_LONG_INT
-MPI_FLOAT                  = 0x4c00040a
-MPI_DOUBLE                 = 0x4c00080b
-MPI_LONG_DOUBLE            = 0x4c00080c
-MPI_BYTE                   = 0x4c00010d
-MPI_WCHAR                  = 0x4c00020e
-MPI_PACKED                 = 0x4c00010f
-MPI_LB                     = 0x4c000010
-MPI_UB                     = 0x4c000011
-MPI_C_COMPLEX              = 0x4c000812
-MPI_C_FLOAT_COMPLEX        = 0x4c000813
-MPI_C_DOUBLE_COMPLEX       = 0x4c001614
-MPI_C_LONG_DOUBLE_COMPLEX  = 0x4c001615
-MPI_2INT                   = 0x4c000816
-MPI_C_BOOL                 = 0x4c000117
-MPI_SIGNED_CHAR            = 0x4c000118
-MPI_UNSIGNED_LONG_LONG     = 0x4c000819
-MPI_CHARACTER              = 0x4c00011a
-MPI_INTEGER                = 0x4c00041b
-MPI_REAL                   = 0x4c00041c
-MPI_LOGICAL                = 0x4c00041d
-MPI_COMPLEX                = 0x4c00081e
-MPI_DOUBLE_PRECISION       = 0x4c00081f
-MPI_2INTEGER               = 0x4c000820
-MPI_2REAL                  = 0x4c000821
-MPI_DOUBLE_COMPLEX         = 0x4c001022
-MPI_2DOUBLE_PRECISION      = 0x4c001023
-MPI_2COMPLEX               = 0x4c001024
-MPI_2DOUBLE_COMPLEX        = 0x4c002025
-MPI_REAL2                  = MPI_DATATYPE_NULL
-MPI_REAL4                  = 0x4c000427
-MPI_COMPLEX8               = 0x4c000828
-MPI_REAL8                  = 0x4c000829
-MPI_COMPLEX16              = 0x4c00102a
-MPI_REAL16                 = MPI_DATATYPE_NULL
-MPI_COMPLEX32              = MPI_DATATYPE_NULL
-MPI_INTEGER1               = 0x4c00012d
-MPI_COMPLEX4               = MPI_DATATYPE_NULL
-MPI_INTEGER2               = 0x4c00022f
-MPI_INTEGER4               = 0x4c000430
-MPI_INTEGER8               = 0x4c000831
-MPI_INTEGER16              = MPI_DATATYPE_NULL
-MPI_INT8_T                 = 0x4c000133
-MPI_INT16_T                = 0x4c000234
-MPI_INT32_T                = 0x4c000435
-MPI_INT64_T                = 0x4c000836
-MPI_UINT8_T                = 0x4c000137
-MPI_UINT16_T               = 0x4c000238
-MPI_UINT32_T               = 0x4c000439
-MPI_UINT64_T               = 0x4c00083a
-MPI_AINT                   = 0x4c00083b
-MPI_OFFSET                 = 0x4c00083c
-MPI_FLOAT_INT              = 0x8c000000
-MPI_DOUBLE_INT             = 0x8c000001
-MPI_LONG_INT               = 0x8c000002
-MPI_SHORT_INT              = 0x8c000003
-MPI_LONG_DOUBLE_INT        = 0x8c000004
-
-#TEMP: Datatype mapping
-_TYPES_NP2MPI_RAW = {
-    np.int8: MPI_INT8_T,
-    np.int16: MPI_INT16_T,
-    np.int32: MPI_INT32_T,
-    np.int64: MPI_INT64_T,
-    np.uint8: MPI_UINT8_T,
-    np.uint16: MPI_UINT16_T,
-    np.uint32: MPI_UINT32_T,
-    np.uint64: MPI_UINT64_T,
-    np.float32: MPI_FLOAT,
-    np.float64: MPI_DOUBLE,
-    np.float_: MPI_DOUBLE,
-    np.complex64: MPI_COMPLEX,
-    np.complex128: MPI_DOUBLE_COMPLEX,
-    np.complex_: MPI_C_LONG_DOUBLE_COMPLEX,
-    np.bool_: MPI_CHAR,
-    np.byte: MPI_CHAR,
-    np.ubyte: MPI_UNSIGNED_CHAR,
-    np.short: MPI_SHORT,
-    np.ushort: MPI_UNSIGNED_SHORT,
-    np.intc: MPI_INT,
-    np.uintc: MPI_UNSIGNED,
-    np.int_: MPI_LONG,
-    np.uint: MPI_UNSIGNED_LONG,
-    np.longlong: MPI_LONG_LONG,
-    np.ulonglong: MPI_UNSIGNED_LONG_LONG,
-    np.half: MPI_REAL2,
-    np.float16: MPI_REAL2,
-    np.intp: MPI_DATATYPE_NULL, # ???
-    np.uintp: MPI_DATATYPE_NULL, # ???
-    np.single: MPI_FLOAT,
-    np.double: MPI_DOUBLE,
-    np.longdouble: MPI_LONG_DOUBLE,
-    np.csingle: MPI_FLOAT,
-    np.cdouble: MPI_DOUBLE,
-    np.clongdouble: MPI_LONG_DOUBLE}
-
-_NP2MPI_max_num = max(np.dtype(dt).num for dt in _TYPES_NP2MPI_RAW)
-_TYPES_NP2MPI = np.empty(_NP2MPI_max_num + 1, dtype=np.intc)
-for k, v in _TYPES_NP2MPI_RAW.items():
-    _TYPES_NP2MPI[np.dtype(k).num] = v
-
-@numba.njit
-def _MPI_get_type_as_int(dtype):
-    return _TYPES_NP2MPI[dtype.num].ctypes.data
-
 # int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,  MPI_Comm comm)
 @numba.njit
 def send(data, dest, tag):
-    result = _MPI_Send(x.ctypes.data, x.size, _MPI_get_type_as_int(x.dtype), dest, tag, _MPI_Comm_world())
+    result = _MPI_Send(data.ctypes.data, data.size, _MPI_Double(), dest, tag, _MPI_Comm_world())
     assert result == 0
 
 #int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status * status)
 @numba.njit()
 def recv(data, source, tag):
-    status = np.empty((5,), dtype=np.intc)
-    result = _MPI_Recv(x.ctypes.data, x.size, _MPI_get_type_as_int(x.dtype), source, tag, _MPI_Comm_world(), status.ctypes.data)
+    status = np.empty(5, dtype=np.intc)
+    result = _MPI_Recv(data.ctypes.data, data.size, _MPI_Double(), source, tag, _MPI_Comm_world(), status.ctypes.data)

--- a/MPyDATA/mpi.py
+++ b/MPyDATA/mpi.py
@@ -107,7 +107,7 @@ MPI_UNSIGNED               = 0x4c000406
 MPI_LONG                   = 0x4c000407
 MPI_UNSIGNED_LONG          = 0x4c000408
 MPI_LONG_LONG_INT          = 0x4c000809
-MPI_LONG_LONG              = MPI_LONG_LONG_INT,
+MPI_LONG_LONG              = MPI_LONG_LONG_INT
 MPI_FLOAT                  = 0x4c00040a
 MPI_DOUBLE                 = 0x4c00080b
 MPI_LONG_DOUBLE            = 0x4c00080c
@@ -148,7 +148,7 @@ MPI_COMPLEX4               = MPI_DATATYPE_NULL
 MPI_INTEGER2               = 0x4c00022f
 MPI_INTEGER4               = 0x4c000430
 MPI_INTEGER8               = 0x4c000831
-MPI_INTEGER16              = MPI_DATATYPE_NULL,
+MPI_INTEGER16              = MPI_DATATYPE_NULL
 MPI_INT8_T                 = 0x4c000133
 MPI_INT16_T                = 0x4c000234
 MPI_INT32_T                = 0x4c000435
@@ -210,7 +210,7 @@ for k, v in _TYPES_NP2MPI_RAW.items():
 
 @numba.njit
 def _MPI_get_type_as_int(dtype):
-    return int(_TYPES_NP2MPI[dtype.num])
+    return _TYPES_NP2MPI[dtype.num].ctypes.data
 
 # int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,  MPI_Comm comm)
 @numba.njit
@@ -221,5 +221,5 @@ def send(data, dest, tag):
 #int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status * status)
 @numba.njit()
 def recv(data, source, tag):
-    status = np.empty(5, dtype=np.intc)
+    status = np.empty((5,), dtype=np.intc)
     result = _MPI_Recv(x.ctypes.data, x.size, _MPI_get_type_as_int(x.dtype), source, tag, _MPI_Comm_world(), status.ctypes.data)

--- a/MPyDATA/mpi.py
+++ b/MPyDATA/mpi.py
@@ -9,7 +9,12 @@ if MPI._sizeof(MPI.Comm) == ctypes.sizeof(ctypes.c_int):
     _MPI_Comm_t = ctypes.c_int
 else:
     _MPI_Comm_t = ctypes.c_void_p
-_MPI_Datatype_t = ctypes.c_void_p
+
+if MPI._sizeof(MPI.Datatype) == ctypes.sizeof(ctypes.c_int):
+    _MPI_Datatype_t = ctypes.c_int
+else:
+    _MPI_Datatype_t = ctypes.c_void_p
+
 _MPI_Status_ptr_t = ctypes.c_void_p
 
 if platform.system() == 'Linux':
@@ -124,3 +129,4 @@ def send(data, dest, tag):
 def recv(data, source, tag):
     status = np.empty(5, dtype=np.intc)
     result = _MPI_Recv(data.ctypes.data, data.size, _MPI_Double(), source, tag, _MPI_Comm_world(), status.ctypes.data)
+    assert result == 0

--- a/MPyDATA/mpi.py
+++ b/MPyDATA/mpi.py
@@ -9,6 +9,7 @@ if MPI._sizeof(MPI.Comm) == ctypes.sizeof(ctypes.c_int):
     _MPI_Comm_t = ctypes.c_int
 else:
     _MPI_Comm_t = ctypes.c_void_p
+_MPI_Datatype_t = ctypes.c_int
 
 if platform.system() == 'Linux':
     lib = 'libmpi.so'
@@ -34,6 +35,15 @@ _MPI_Comm_rank.argtypes = [_MPI_Comm_t, ctypes.c_void_p]
 
 _MPI_Comm_World_ptr = MPI._addressof(MPI.COMM_WORLD)
 
+# int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,  MPI_Comm comm)
+_MPI_Send = libmpi.MPI_Send
+_MPI_Send.restype = ctypes.c_int
+_MPI_Send.argtypes = [ctypes.c_void_p, ctypes.c_int, _MPI_Datatype_t, ctypes.c_int, ctypes.c_int, _MPI_Comm_t]
+
+#int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status * status)
+_MPI_Recv = libmpi.MPI_Recv
+_MPI_Recv.restype = ctypes.c_int
+_MPI_Recv.argtypes = [ctypes.c_void_p, ctypes.c_int, _MPI_Datatype_t, ctypes.c_int, ctypes.c_int, _MPI_Comm_t, _MPI_Status_ptr_t]
 
 def _MPI_Comm_world():
     return _MPI_Comm_t.from_address(_MPI_Comm_World_ptr)
@@ -84,3 +94,131 @@ def rank():
     status = _MPI_Comm_rank(_MPI_Comm_world(), value.ctypes.data)
     assert status == 0
     return value[0]
+
+# TEMP: from WIN MSDN (https://docs.microsoft.com/en-us/message-passing-interface/mpi-datatype-enumeration)
+MPI_DATATYPE_NULL          = 0x0c000000
+MPI_CHAR                   = 0x4c000101
+MPI_UNSIGNED_CHAR          = 0x4c000102
+MPI_SHORT                  = 0x4c000203
+MPI_UNSIGNED_SHORT         = 0x4c000204
+MPI_INT                    = 0x4c000405
+MPI_UNSIGNED               = 0x4c000406
+MPI_LONG                   = 0x4c000407
+MPI_UNSIGNED_LONG          = 0x4c000408
+MPI_LONG_LONG_INT          = 0x4c000809
+MPI_LONG_LONG              = MPI_LONG_LONG_INT,
+MPI_FLOAT                  = 0x4c00040a
+MPI_DOUBLE                 = 0x4c00080b
+MPI_LONG_DOUBLE            = 0x4c00080c
+MPI_BYTE                   = 0x4c00010d
+MPI_WCHAR                  = 0x4c00020e
+MPI_PACKED                 = 0x4c00010f
+MPI_LB                     = 0x4c000010
+MPI_UB                     = 0x4c000011
+MPI_C_COMPLEX              = 0x4c000812
+MPI_C_FLOAT_COMPLEX        = 0x4c000813
+MPI_C_DOUBLE_COMPLEX       = 0x4c001614
+MPI_C_LONG_DOUBLE_COMPLEX  = 0x4c001615
+MPI_2INT                   = 0x4c000816
+MPI_C_BOOL                 = 0x4c000117
+MPI_SIGNED_CHAR            = 0x4c000118
+MPI_UNSIGNED_LONG_LONG     = 0x4c000819
+MPI_CHARACTER              = 0x4c00011a
+MPI_INTEGER                = 0x4c00041b
+MPI_REAL                   = 0x4c00041c
+MPI_LOGICAL                = 0x4c00041d
+MPI_COMPLEX                = 0x4c00081e
+MPI_DOUBLE_PRECISION       = 0x4c00081f
+MPI_2INTEGER               = 0x4c000820
+MPI_2REAL                  = 0x4c000821
+MPI_DOUBLE_COMPLEX         = 0x4c001022
+MPI_2DOUBLE_PRECISION      = 0x4c001023
+MPI_2COMPLEX               = 0x4c001024
+MPI_2DOUBLE_COMPLEX        = 0x4c002025
+MPI_REAL2                  = MPI_DATATYPE_NULL
+MPI_REAL4                  = 0x4c000427
+MPI_COMPLEX8               = 0x4c000828
+MPI_REAL8                  = 0x4c000829
+MPI_COMPLEX16              = 0x4c00102a
+MPI_REAL16                 = MPI_DATATYPE_NULL
+MPI_COMPLEX32              = MPI_DATATYPE_NULL
+MPI_INTEGER1               = 0x4c00012d
+MPI_COMPLEX4               = MPI_DATATYPE_NULL
+MPI_INTEGER2               = 0x4c00022f
+MPI_INTEGER4               = 0x4c000430
+MPI_INTEGER8               = 0x4c000831
+MPI_INTEGER16              = MPI_DATATYPE_NULL,
+MPI_INT8_T                 = 0x4c000133
+MPI_INT16_T                = 0x4c000234
+MPI_INT32_T                = 0x4c000435
+MPI_INT64_T                = 0x4c000836
+MPI_UINT8_T                = 0x4c000137
+MPI_UINT16_T               = 0x4c000238
+MPI_UINT32_T               = 0x4c000439
+MPI_UINT64_T               = 0x4c00083a
+MPI_AINT                   = 0x4c00083b
+MPI_OFFSET                 = 0x4c00083c
+MPI_FLOAT_INT              = 0x8c000000
+MPI_DOUBLE_INT             = 0x8c000001
+MPI_LONG_INT               = 0x8c000002
+MPI_SHORT_INT              = 0x8c000003
+MPI_LONG_DOUBLE_INT        = 0x8c000004
+
+#TEMP: Datatype mapping
+_TYPES_NP2MPI_RAW = {
+    np.int8: MPI_INT8_T,
+    np.int16: MPI_INT16_T,
+    np.int32: MPI_INT32_T,
+    np.int64: MPI_INT64_T,
+    np.uint8: MPI_UINT8_T,
+    np.uint16: MPI_UINT16_T,
+    np.uint32: MPI_UINT32_T,
+    np.uint64: MPI_UINT64_T,
+    np.float32: MPI_FLOAT,
+    np.float64: MPI_DOUBLE,
+    np.float_: MPI_DOUBLE,
+    np.complex64: MPI_COMPLEX,
+    np.complex128: MPI_DOUBLE_COMPLEX,
+    np.complex_: MPI_C_LONG_DOUBLE_COMPLEX,
+    np.bool_: MPI_CHAR,
+    np.byte: MPI_CHAR,
+    np.ubyte: MPI_UNSIGNED_CHAR,
+    np.short: MPI_SHORT,
+    np.ushort: MPI_UNSIGNED_SHORT,
+    np.intc: MPI_INT,
+    np.uintc: MPI_UNSIGNED,
+    np.int_: MPI_LONG,
+    np.uint: MPI_UNSIGNED_LONG,
+    np.longlong: MPI_LONG_LONG,
+    np.ulonglong: MPI_UNSIGNED_LONG_LONG,
+    np.half: MPI_REAL2,
+    np.float16: MPI_REAL2,
+    np.intp: MPI_DATATYPE_NULL, # ???
+    np.uintp: MPI_DATATYPE_NULL, # ???
+    np.single: MPI_FLOAT,
+    np.double: MPI_DOUBLE,
+    np.longdouble: MPI_LONG_DOUBLE,
+    np.csingle: MPI_FLOAT,
+    np.cdouble: MPI_DOUBLE,
+    np.clongdouble: MPI_LONG_DOUBLE}
+
+_NP2MPI_max_num = max(np.dtype(dt).num for dt in _TYPES_NP2MPI_RAW)
+_TYPES_NP2MPI = np.empty(_NP2MPI_max_num + 1, dtype=np.intc)
+for k, v in _TYPES_NP2MPI_RAW.items():
+    _TYPES_NP2MPI[np.dtype(k).num] = v
+
+@numba.njit
+def _MPI_get_type_as_int(dtype):
+    return int(_TYPES_NP2MPI[dtype.num])
+
+# int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,  MPI_Comm comm)
+@numba.njit
+def send(data, dest, tag):
+    result = _MPI_Send(x.ctypes.data, x.size, _MPI_get_type_as_int(x.dtype), dest, tag, _MPI_Comm_world())
+    assert result == 0
+
+#int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status * status)
+@numba.njit()
+def recv(data, source, tag):
+    status = np.empty(5, dtype=np.intc)
+    result = _MPI_Recv(x.ctypes.data, x.size, _MPI_get_type_as_int(x.dtype), source, tag, _MPI_Comm_world(), status.ctypes.data)

--- a/MPyDATA/mpi.py
+++ b/MPyDATA/mpi.py
@@ -10,6 +10,7 @@ if MPI._sizeof(MPI.Comm) == ctypes.sizeof(ctypes.c_int):
 else:
     _MPI_Comm_t = ctypes.c_void_p
 _MPI_Datatype_t = ctypes.c_int
+_MPI_Status_ptr_t = ctypes.c_void_p
 
 if platform.system() == 'Linux':
     lib = 'libmpi.so'

--- a/MPyDATA_tests/unit_tests/test_mpi.py
+++ b/MPyDATA_tests/unit_tests/test_mpi.py
@@ -26,18 +26,17 @@ class TestMPI:
     @pytest.mark.parametrize("snd, rcv", [(mpi.send, mpi.recv), (mpi.send.py_func, mpi.recv.py_func)])
     @pytest.mark.parametrize("dt", [np.intc, np.float32, np.float64, np.uint8])
     def test_send_recv(snd, rcv, dt):
-        if mpi.size() > 1:
-            src = np.array([1, 2, 3, 4, 5], dtype=dt)
-            dst_tst = np.empty(5, dtype=dt)
-            dst_exp = np.empty(5, dtype=dt)
+        src = np.array([1, 2, 3, 4, 5], dtype=dt)
+        dst_tst = np.empty(5, dtype=dt)
+        dst_exp = np.empty(5, dtype=dt)
 
-            if mpi.rank() == 0:
-                snd(src, dest=1, tag=11)
-                COMM_WORLD.Send(src, dest=1, tag=22)
-            elif mpi.rank() == 1:
-                rcv(dst_tst, source=0, tag=11)
-                COMM_WORLD.Recv(dst_exp, source=0, tag=22)
+        if mpi.rank() == 0:
+            snd(src, dest=1, tag=11)
+            COMM_WORLD.Send(src, dest=1, tag=22)
+        elif mpi.rank() == 1:
+            rcv(dst_tst, source=0, tag=11)
+            COMM_WORLD.Recv(dst_exp, source=0, tag=22)
 
-                assert np.all(dst_tst, src)
-                assert np.all(dst_tst, dst_exp)
+            assert np.all(dst_tst == src)
+            assert np.all(dst_tst == dst_exp)
 

--- a/MPyDATA_tests/unit_tests/test_mpi.py
+++ b/MPyDATA_tests/unit_tests/test_mpi.py
@@ -24,7 +24,7 @@ class TestMPI:
 
     @staticmethod
     @pytest.mark.parametrize("snd, rcv", [(mpi.send, mpi.recv), (mpi.send.py_func, mpi.recv.py_func)])
-    @pytest.mark.parametrize("dt", [np.intc, np.float32, np.float64, np.uint8])
+    @pytest.mark.parametrize("dt", [np.float64])
     def test_send_recv(snd, rcv, dt):
         src = np.array([1, 2, 3, 4, 5], dtype=dt)
         dst_tst = np.empty(5, dtype=dt)

--- a/MPyDATA_tests/unit_tests/test_mpi.py
+++ b/MPyDATA_tests/unit_tests/test_mpi.py
@@ -25,7 +25,7 @@ class TestMPI:
     @staticmethod
     @pytest.mark.parametrize("snd, rcv", [(mpi.send, mpi.recv), (mpi.send.py_func, mpi.recv.py_func)])
     @pytest.mark.parametrize("dt", [np.intc, np.float32, np.float64, np.uint8])
-    def test_send_recv(sut):
+    def test_send_recv(snd, rcv, dt):
         if mpi.size() > 1:
             src = np.array([1, 2, 3, 4, 5], dtype=dt)
             dst_tst = np.empty(5, dtype=dt)

--- a/MPyDATA_tests/unit_tests/test_mpi.py
+++ b/MPyDATA_tests/unit_tests/test_mpi.py
@@ -1,5 +1,6 @@
 import MPyDATA.mpi as mpi
 from mpi4py.MPI import COMM_WORLD
+import numpy as np
 import pytest
 
 
@@ -20,4 +21,23 @@ class TestMPI:
     def test_rank(sut):
         rank = sut()
         assert rank == COMM_WORLD.Get_rank()
+
+    @staticmethod
+    @pytest.mark.parametrize("snd, rcv", [(mpi.send, mpi.recv), (mpi.send.py_func, mpi.recv.py_func)])
+    @pytest.mark.parametrize("dt", [np.intc, np.float32, np.float64, np.uint8])
+    def test_send_recv(sut):
+        if mpi.size() > 1:
+            src = np.array([1, 2, 3, 4, 5], dtype=dt)
+            dst_tst = np.empty(5, dtype=dt)
+            dst_exp = np.empty(5, dtype=dt)
+
+            if mpi.rank() == 0:
+                snd(src, dest=1, tag=11)
+                COMM_WORLD.Send(src, dest=1, tag=22)
+            elif mpi.rank() == 1:
+                rcv(dst_tst, source=0, tag=11)
+                COMM_WORLD.Recv(dst_exp, source=0, tag=22)
+
+                assert np.all(dst_tst, src)
+                assert np.all(dst_tst, dst_exp)
 


### PR DESCRIPTION
First attempt at providing ```numba```-enabled wrappers for MPI functions ```send``` and ```recv```.

**Added:**
- in ```mpi.py```: wrappers for MPI functions ```send``` and ```recv``` with signature similar to those used in ```mpi4py``` (currently only allows ```numpy``` arrays as data source/destination, element types and counts are inferred from ```np.array``` settings); current handling of MPI datatypes is messy and hacky, and requires improvement. (EDIT: currently only supports arrays of doubles (i.e. ```np.float64```), but can be extended to other types)
- in ```test_mpi.py```: single test function for both functions, that requires 2 MPI threads (0 is sending, 1 is receiving).
- in ```.travis.yml``` - currently only added ```mpirun -n 2``` to execution of ```pytest``` - probably should be improved to run only relevant test cases with MPI (EDIT: Added separate calls for - for the time being - non-MPI enabled tests, i.e. all besides ```test_mpi.py```; and MPI enabled tests, i.e. only ```test_mpi.py``` for now, that are being executed using ```mpirun -n 2``` or equivalent)

EDIT: Note, that running of MPI enabled tests was excluded from travis build for Windows, as using standard setup, paths, etc. yields error: ```mpiexec command not found```.