### PR TITLE
workaround for newer Numba versions which err if a jitclass has a __call__ method

### DIFF
--- a/PyMPDATA/solver.py
+++ b/PyMPDATA/solver.py
@@ -19,7 +19,7 @@ class PostStepNull:  # pylint: disable=too-few-public-methods
     def __init__(self):
         pass
 
-    def __call__(self, psi, step):  # pylint: disable-next=unused-argument
+    def call(self, psi, step):  # pylint: disable-next=unused-argument
         pass
 
 
@@ -30,9 +30,7 @@ class PostIterNull:  # pylint: disable=too-few-public-methods
     def __init__(self):
         pass
 
-    def __call__(
-        self, flux, g_factor, step, iteration
-    ):  # pylint: disable=unused-argument
+    def call(self, flux, g_factor, step, iteration):  # pylint: disable=unused-argument
         pass
 
 
@@ -115,7 +113,7 @@ class Solver:
     ):
         """advances solution by `n_steps` steps, optionally accepts: a tuple of diffusion
         coefficients (one value per dimension) as well as `post_iter` and `post_step`
-        callbacks expected to be `numba.jitclass`es with a `__call__` method, for
+        callbacks expected to be `numba.jitclass`es with a `call` method, for
         signature see `PostStepNull` and `PostIterNull`;
         returns CPU time per timestep (units as returned by `clock.clock()`)"""
         if mu_coeff is not None:

--- a/PyMPDATA/solver.py
+++ b/PyMPDATA/solver.py
@@ -20,6 +20,7 @@ class PostStepNull:  # pylint: disable=too-few-public-methods
         pass
 
     def call(self, psi, step):  # pylint: disable-next=unused-argument
+        """think of it as a `__call__` method (which Numba does not allow)"""
         pass
 
 
@@ -31,6 +32,7 @@ class PostIterNull:  # pylint: disable=too-few-public-methods
         pass
 
     def call(self, flux, g_factor, step, iteration):  # pylint: disable=unused-argument
+        """think of it as a `__call__` method (which Numba does not allow)"""
         pass
 
 

--- a/PyMPDATA/solver.py
+++ b/PyMPDATA/solver.py
@@ -21,7 +21,6 @@ class PostStepNull:  # pylint: disable=too-few-public-methods
 
     def call(self, psi, step):  # pylint: disable-next=unused-argument
         """think of it as a `__call__` method (which Numba does not allow)"""
-        pass
 
 
 @numba.experimental.jitclass([])
@@ -33,7 +32,6 @@ class PostIterNull:  # pylint: disable=too-few-public-methods
 
     def call(self, flux, g_factor, step, iteration):  # pylint: disable=unused-argument
         """think of it as a `__call__` method (which Numba does not allow)"""
-        pass
 
 
 class Solver:

--- a/PyMPDATA/stepper.py
+++ b/PyMPDATA/stepper.py
@@ -211,10 +211,10 @@ def make_step_impl(
                         nonoscillatory_correction(null_impl, advector_nonos, beta)
                         flux_subsequent(null_impl, flux, advectee, advector_nonos)
                 upwind(null_impl, advectee, flux, g_factor)
-                post_iter.__call__(flux.field, g_factor.field, step, iteration)
+                post_iter.call(flux.field, g_factor.field, step, iteration)
             if non_zero_mu_coeff:
                 advector = advector_orig
-            post_step.__call__(advectee.field[ARG_DATA], step)
+            post_step.call(advectee.field[ARG_DATA], step)
         return (clock() - time) / n_steps if n_steps > 0 else np.nan
 
     return step, traversals

--- a/examples/PyMPDATA_examples/Arabas_and_Farhat_2020/simulation.py
+++ b/examples/PyMPDATA_examples/Arabas_and_Farhat_2020/simulation.py
@@ -98,7 +98,7 @@ class Simulation:
                 def __init__(self):
                     pass
 
-                def __call__(self, psi, step):
+                def call(self, psi, step):
                     t = T - (step + 1) * dt
                     psi += np.maximum(psi, f_T / np.exp(r * t)) - psi
 

--- a/examples/PyMPDATA_examples/Shipway_and_Hill_2012/fig_1.ipynb
+++ b/examples/PyMPDATA_examples/Shipway_and_Hill_2012/fig_1.ipynb
@@ -141,7 +141,7 @@
     "                    def __init__(self):\n",
     "                        self.dpsi_cond = np.zeros(dpsi_shape)\n",
     "\n",
-    "                    def call(self, flux, g_factor, t, it):\n",
+    "                    def call(self, flux, g_factor, t, it):  # pylint: disable=unused-argument\n",
     "                        if it == 0:\n",
     "                            self.dpsi_cond[:] = 0\n",
     "                        flux_wo_halo = flux[ARG_DATA_INNER][halo:-halo, halo-1:halo-1 + nr+ONE_FOR_STAGGERED_GRID]\n",

--- a/examples/PyMPDATA_examples/Shipway_and_Hill_2012/fig_1.ipynb
+++ b/examples/PyMPDATA_examples/Shipway_and_Hill_2012/fig_1.ipynb
@@ -141,7 +141,7 @@
     "                    def __init__(self):\n",
     "                        self.dpsi_cond = np.zeros(dpsi_shape)\n",
     "\n",
-    "                    def __call__(self, flux, g_factor, t, it):\n",
+    "                    def call(self, flux, g_factor, t, it):\n",
     "                        if it == 0:\n",
     "                            self.dpsi_cond[:] = 0\n",
     "                        flux_wo_halo = flux[ARG_DATA_INNER][halo:-halo, halo-1:halo-1 + nr+ONE_FOR_STAGGERED_GRID]\n",


### PR DESCRIPTION
see https://github.com/numba/numba/commit/87b44afc89ff71ac6a569a898953786287dd8eb8